### PR TITLE
feat: Make map bubbles clickable to view lead details

### DIFF
--- a/app.log
+++ b/app.log
@@ -1,6 +1,0 @@
- * Serving Flask app 'app'
- * Debug mode: on
-[31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
- * Running on http://127.0.0.1:5001
-[33mPress CTRL+C to quit[0m
- * Restarting with stat

--- a/static/js/lead_detail.js
+++ b/static/js/lead_detail.js
@@ -1,7 +1,12 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const leadNameEl = document.getElementById('lead-name');
+    // --- Element Selectors ---
+    const leadForm = document.getElementById('lead-form');
+    const leadNameHeaderEl = document.getElementById('lead-name-header');
+    const leadNameInput = document.getElementById('lead-name');
     const leadStatusEl = document.getElementById('lead-status');
-    const leadPhoneEl = document.getElementById('lead-phone');
+    const leadPhoneInput = document.getElementById('lead-phone');
+    const editBtn = document.getElementById('edit-btn');
+    const saveBtn = document.getElementById('save-btn');
     const callBtn = document.getElementById('call-btn');
     const textBtn = document.getElementById('text-btn');
     const notesListEl = document.getElementById('notes-list');
@@ -10,12 +15,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
     let currentLead = null;
 
+    // --- Functions ---
     const fetchLeadData = async () => {
         try {
             const response = await fetch(`/api/leads/${LEAD_ID}`);
-            if (!response.ok) {
-                throw new Error('Lead not found');
-            }
+            if (!response.ok) throw new Error('Lead not found');
             currentLead = await response.json();
             renderLeadData();
         } catch (error) {
@@ -27,14 +31,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const renderLeadData = () => {
         if (!currentLead) return;
 
-        leadNameEl.textContent = currentLead.name;
+        // Use header for display, input for editing
+        leadNameHeaderEl.textContent = currentLead.name;
+        leadNameInput.value = currentLead.name;
         leadStatusEl.textContent = currentLead.status;
-        leadPhoneEl.textContent = currentLead.phone;
+        leadPhoneInput.value = currentLead.phone;
+
+        // Toggle visibility based on edit mode
+        leadNameHeaderEl.style.display = 'block';
+        leadNameInput.style.display = 'none';
 
         // Set up communication links
         if (currentLead.phone) {
             callBtn.href = `tel:${currentLead.phone}`;
             textBtn.href = `sms:${currentLead.phone}`;
+            callBtn.style.display = 'inline-block';
+            textBtn.style.display = 'inline-block';
         } else {
             callBtn.style.display = 'none';
             textBtn.style.display = 'none';
@@ -42,11 +54,54 @@ document.addEventListener('DOMContentLoaded', () => {
 
         // Render notes
         notesListEl.innerHTML = '';
-        currentLead.notes.forEach(note => {
-            const li = document.createElement('li');
-            li.textContent = note;
-            notesListEl.appendChild(li);
-        });
+        if (currentLead.notes && currentLead.notes.length > 0) {
+            currentLead.notes.forEach(note => {
+                const li = document.createElement('li');
+                li.textContent = note;
+                notesListEl.appendChild(li);
+            });
+        } else {
+            notesListEl.innerHTML = '<li>No notes yet.</li>';
+        }
+    };
+
+    const setEditMode = (isEditing) => {
+        leadNameInput.readOnly = !isEditing;
+        leadPhoneInput.readOnly = !isEditing;
+
+        // Toggle visibility of header vs. input for the name
+        leadNameHeaderEl.style.display = isEditing ? 'none' : 'block';
+        leadNameInput.style.display = isEditing ? 'block' : 'none';
+
+        editBtn.style.display = isEditing ? 'none' : 'inline-block';
+        saveBtn.style.display = isEditing ? 'inline-block' : 'none';
+    };
+
+    const handleFormSubmit = async (e) => {
+        e.preventDefault();
+        const updatedData = {
+            name: leadNameInput.value,
+            phone: leadPhoneInput.value,
+        };
+
+        try {
+            const response = await fetch(`/api/leads/${LEAD_ID}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(updatedData),
+            });
+
+            if (response.ok) {
+                currentLead = await response.json();
+                renderLeadData();
+                setEditMode(false);
+            } else {
+                alert('Failed to save changes.');
+            }
+        } catch (error) {
+            console.error('Error saving lead data:', error);
+            alert('An error occurred while saving.');
+        }
     };
 
     const handleAddNote = async (e) => {
@@ -54,21 +109,19 @@ document.addEventListener('DOMContentLoaded', () => {
         const newNote = noteTextEl.value.trim();
         if (!newNote || !currentLead) return;
 
-        const updatedNotes = [...currentLead.notes, newNote];
+        const updatedNotes = [...(currentLead.notes || []), newNote];
 
         try {
             const response = await fetch(`/api/leads/${LEAD_ID}`, {
                 method: 'PUT',
-                headers: {
-                    'Content-Type': 'application/json',
-                },
+                headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ notes: updatedNotes }),
             });
 
             if (response.ok) {
                 currentLead = await response.json();
-                renderLeadData(); // Re-render the data
-                noteTextEl.value = ''; // Clear the textarea
+                renderLeadData();
+                noteTextEl.value = '';
             } else {
                 alert('Failed to add note.');
             }
@@ -78,7 +131,11 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
+    // --- Event Listeners ---
+    editBtn.addEventListener('click', () => setEditMode(true));
+    leadForm.addEventListener('submit', handleFormSubmit);
     addNoteForm.addEventListener('submit', handleAddNote);
 
+    // --- Initial Load ---
     fetchLeadData();
 });

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -23,19 +23,10 @@ document.addEventListener('DOMContentLoaded', () => {
     const leadMarkers = []; // Array to store all lead marker layers
     let allLeads = {}; // Object to store full lead data by ID
 
-    // --- Modal Elements ---
-    const editModal = document.getElementById('edit-modal');
-    const editForm = document.getElementById('edit-form');
-    const leadIdInput = document.getElementById('edit-lead-id');
-    const nameInput = document.getElementById('edit-name');
-    const phoneInput = document.getElementById('edit-phone');
-    const notesInput = document.getElementById('edit-notes');
-
     // --- Functions ---
     const generatePopupContent = (lead) => {
-        return `<b>${lead.name || 'Unnamed Lead'}</b><br>
-                ${lead.phone || ''}<br>
-                <button class="edit-lead-btn" data-lead-id="${lead.id}">Edit</button>`;
+        // Simplified popup, now just shows info. The marker itself will be clickable.
+        return `<b>${lead.name || 'Unnamed Lead'}</b><br>${lead.status}`;
     };
 
     const addLeadMarker = (lead) => {
@@ -43,6 +34,12 @@ document.addEventListener('DOMContentLoaded', () => {
             const marker = L.marker([lead.address.lat, lead.address.lng]);
             marker.bindPopup(generatePopupContent(lead));
             marker.leadData = lead; // Store full lead data on the marker
+
+            // Make the marker clickable to navigate to the lead detail page
+            marker.on('click', () => {
+                window.location.href = `/leads/${lead.id}`;
+            });
+
             leadMarkers.push(marker);
             marker.addTo(map);
         }
@@ -78,45 +75,19 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     };
 
-    window.openEditModal = (leadId) => {
-        const lead = allLeads[leadId];
-        if (!lead) return;
-
-        leadIdInput.value = lead.id;
-        nameInput.value = lead.name;
-        phoneInput.value = lead.phone;
-        // Notes are now an array, join them with a newline for editing
-        notesInput.value = lead.notes.join('\n');
-        editModal.style.display = 'flex';
-    };
-
-    window.closeEditModal = () => {
-        editModal.style.display = 'none';
-    };
-
     // --- Event Listeners ---
     document.querySelectorAll('#filter-container input').forEach(cb => cb.addEventListener('change', updateMapFilters));
 
-    // Use event delegation for edit buttons in popups
-    map.on('popupopen', (e) => {
-        const btn = e.popup._container.querySelector('.edit-lead-btn');
-        if (btn) {
-            btn.addEventListener('click', () => {
-                const leadId = btn.dataset.leadId;
-                openEditModal(leadId);
-            });
-        }
-    });
-
-    // New lead creation
+    // New lead creation on map click (simplified)
     map.on('click', async (e) => {
-        const leadName = prompt("Enter lead name:");
-        if (leadName === null) return;
-        const leadPhone = prompt("Enter lead phone number:");
-        if (leadPhone === null) return;
+        const leadName = prompt("Enter new lead name:");
+        if (!leadName) return; // Exit if user cancels or enters nothing
 
+        // For simplicity, we're only asking for the name.
+        // The address is the clicked point. Phone/notes can be added on the detail page.
         const newLead = {
-            name: leadName, phone: leadPhone,
+            name: leadName,
+            phone: '', // Initially blank
             address: { lat: e.latlng.lat, lng: e.latlng.lng }
         };
 
@@ -127,49 +98,14 @@ document.addEventListener('DOMContentLoaded', () => {
                 body: JSON.stringify(newLead),
             });
             if (response.ok) {
-                await loadLeads(); // Reload all leads to get the new one
+                const createdLead = await response.json();
+                // Immediately redirect to the new lead's detail page
+                window.location.href = `/leads/${createdLead.id}`;
             } else {
                 alert('Failed to create lead.');
             }
         } catch (error) {
             console.error('Error creating lead:', error);
-        }
-    });
-
-    // Handle modal form submission
-    editForm.addEventListener('submit', async (e) => {
-        e.preventDefault();
-        const leadId = leadIdInput.value;
-        const updatedData = {
-            name: nameInput.value,
-            phone: phoneInput.value,
-            // Split notes back into an array by newline character
-            notes: notesInput.value.split('\n').filter(n => n.trim() !== ''),
-        };
-
-        try {
-            const response = await fetch(`/api/leads/${leadId}`, {
-                method: 'PUT',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify(updatedData),
-            });
-
-            if (response.ok) {
-                const updatedLead = await response.json();
-                // Update local data
-                allLeads[leadId] = updatedLead;
-                // Find and update the marker
-                const markerToUpdate = leadMarkers.find(m => m.leadData.id === leadId);
-                if (markerToUpdate) {
-                    markerToUpdate.leadData = updatedLead;
-                    markerToUpdate.setPopupContent(generatePopupContent(updatedLead));
-                }
-                closeEditModal();
-            } else {
-                alert('Failed to update lead.');
-            }
-        } catch (error) {
-            console.error('Error updating lead:', error);
         }
     });
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,59 +27,6 @@
         #filter-container .filter-option {
             display: block;
         }
-        /* Modal Styles */
-        .modal-backdrop {
-            position: fixed;
-            top: 0;
-            left: 0;
-            width: 100%;
-            height: 100%;
-            background: rgba(0,0,0,0.5);
-            z-index: 1000;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-        }
-        .modal-content {
-            background: white;
-            padding: 20px;
-            border-radius: 8px;
-            width: 90%;
-            max-width: 500px;
-        }
-        .modal-content h3 {
-            margin-top: 0;
-        }
-        .modal-content label {
-            display: block;
-            margin-top: 10px;
-            font-weight: bold;
-        }
-        .modal-content input, .modal-content textarea {
-            width: 100%;
-            padding: 8px;
-            margin-top: 5px;
-            border-radius: 4px;
-            border: 1px solid #ccc;
-        }
-        .modal-actions {
-            margin-top: 20px;
-            text-align: right;
-        }
-        .modal-actions button {
-            padding: 10px 15px;
-            border: none;
-            border-radius: 5px;
-            cursor: pointer;
-        }
-        .btn-save {
-            background-color: #28a745;
-            color: white;
-        }
-        .btn-cancel {
-            background-color: #ccc;
-            margin-left: 10px;
-        }
     </style>
 </head>
 <body>
@@ -102,26 +49,6 @@
             <div class="filter-option"><label><input type="checkbox" name="status" value="Lost" checked> Lost</label></div>
         </div>
     </main>
-
-    <!-- Edit Lead Modal -->
-    <div id="edit-modal" class="modal-backdrop" style="display:none;">
-        <div class="modal-content">
-            <h3>Edit Lead</h3>
-            <form id="edit-form">
-                <input type="hidden" id="edit-lead-id">
-                <label for="edit-name">Name:</label>
-                <input type="text" id="edit-name" required>
-                <label for="edit-phone">Phone:</label>
-                <input type="tel" id="edit-phone">
-                <label for="edit-notes">Notes:</label>
-                <textarea id="edit-notes" rows="4"></textarea>
-                <div class="modal-actions">
-                    <button type="submit" class="btn-save">Save Changes</button>
-                    <button type="button" class="btn-cancel" onclick="closeEditModal()">Cancel</button>
-                </div>
-            </form>
-        </div>
-    </div>
 
     <!-- Leaflet JS -->
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"

--- a/templates/lead_detail.html
+++ b/templates/lead_detail.html
@@ -78,9 +78,21 @@
     </header>
     <main>
         <div id="lead-detail-container" class="lead-detail-container">
-            <h2 id="lead-name"></h2>
-            <p><strong>Status:</strong> <span id="lead-status"></span></p>
-            <p><strong>Phone:</strong> <span id="lead-phone"></span></p>
+            <form id="lead-form">
+                <h2 id="lead-name-header"></h2>
+                <input type="text" id="lead-name" readonly class="editable-field">
+
+                <p><strong>Status:</strong> <span id="lead-status"></span></p>
+
+                <label for="lead-phone"><strong>Phone:</strong></label>
+                <input type="tel" id="lead-phone" readonly class="editable-field">
+
+                <div class="form-actions">
+                    <button type="button" id="edit-btn">Edit</button>
+                    <button type="submit" id="save-btn" style="display:none;">Save</button>
+                </div>
+            </form>
+
             <div class="communication-buttons">
                 <a id="call-btn" href="#">Call</a>
                 <a id="text-btn" href="#">Text</a>


### PR DESCRIPTION
This change modifies the user interaction on the map page.

Instead of a popup with an "Edit" button that opens a modal, the entire map bubble is now clickable. Clicking a bubble navigates the user to the lead's detail page.

On the lead detail page, the information is displayed in a non-editable format by default. An "Edit" button is provided to allow users to switch to an editable mode and save changes.

This simplifies the UI on the map and provides a more dedicated page for viewing and editing lead information.