### PR TITLE
Fix: Correct element ID for status filter

### DIFF
--- a/static/js/map.js
+++ b/static/js/map.js
@@ -39,7 +39,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const phoneInput = document.getElementById('edit-phone');
     const editAddressInput = document.getElementById('edit-address');
     const notesInput = document.getElementById('edit-notes');
-    const statusInput = document.getElementById('edit-status');
+    const statusInput = document.getElementById('_status');
 
 
     // --- Functions ---
@@ -93,7 +93,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
     const buildControlsFromStatuses = (statuses) => {
         const filterContainer = document.getElementById('filter-container');
-        const statusDropdown = document.getElementById('edit-status');
+        const statusDropdown = document.getElementById('_status');
 
         // Clear any existing placeholders
         filterContainer.innerHTML = '<h4>Filter by Status</h4>';


### PR DESCRIPTION
The javascript was attempting to select the status filter dropdown using the ID `edit-status`, but the actual ID of the element in the HTML is `_status`. This commit corrects the ID in the javascript to correctly select the element, allowing the status filters to be loaded and updated correctly.