### PR TITLE
feat: Implement multiple UI improvements to Kanban and lead pages

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -137,6 +137,7 @@ body {
     margin-bottom: 0;
     border-bottom: none;
     border-radius: .25rem;
+    position: relative; /* Add relative positioning */
 }
 
 .kanban-column.collapsed .column-title {
@@ -145,7 +146,12 @@ body {
 }
 
 .kanban-column.collapsed .lead-count {
-    display: none;
+    display: inline-flex; /* Show the count */
+    position: absolute;
+    top: 10px; /* Position at the top */
+    left: 50%;
+    transform: translateX(-50%) rotate(180deg); /* Counter-rotate and center */
+    z-index: 1;
 }
 
 .kanban-column.collapsed .lead-card {
@@ -154,6 +160,15 @@ body {
 
 .lead-card {
     cursor: grab;
+}
+
+.lead-card .card-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 4; /* Limit to 4 lines */
+    -webkit-box-orient: vertical;
+    white-space: normal; /* Override any white-space settings */
 }
 
 .lead-card.dragging {

--- a/static/js/lead_detail.js
+++ b/static/js/lead_detail.js
@@ -23,6 +23,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const leadFirstNameInput = document.getElementById('lead-first-name');
     const leadLastNameInput = document.getElementById('lead-last-name');
     const leadStatusSelect = document.getElementById('lead-status');
+    const leadSourceSelect = document.getElementById('lead-source');
     const leadCreatedAtEl = document.getElementById('lead-created-at');
     const leadPhoneInput = document.getElementById('lead-phone');
     const leadAddressInput = document.getElementById('lead-address');
@@ -36,6 +37,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const adjustPinBtn = document.getElementById('adjust-pin-btn');
     const snoozeLeadBtn = document.getElementById('snooze-lead-btn');
     const viewOnMapBtn = document.getElementById('view-on-map-btn');
+    const hotLeadToggleButton = document.getElementById('hot-lead-toggle-btn');
 
     // --- Snooze Functionality ---
     const snoozeModalEl = document.getElementById('snooze-modal');
@@ -83,6 +85,31 @@ document.addEventListener('DOMContentLoaded', () => {
             showToast('An error occurred while snoozing.', 'error');
         } finally {
             snoozeModal.hide();
+        }
+    };
+
+    const toggleHotLead = async () => {
+        if (!currentLead) return;
+
+        const newHotStatus = !currentLead.is_hot;
+
+        try {
+            const response = await fetch(`/api/leads/${LEAD_ID}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ is_hot: newHotStatus }),
+            });
+
+            if (response.ok) {
+                currentLead = await response.json();
+                renderLeadData(); // Re-render to update button style
+                showToast(`Lead marked as ${newHotStatus ? 'hot' : 'not hot'}.`);
+            } else {
+                showToast('Failed to update hot status.', 'error');
+            }
+        } catch (error) {
+            console.error('Error toggling hot lead:', error);
+            showToast('An error occurred while updating.', 'error');
         }
     };
 
@@ -146,6 +173,7 @@ document.addEventListener('DOMContentLoaded', () => {
         leadPhoneInput.value = currentLead.phone || '';
         leadAddressInput.value = currentLead.address?.full_address || '';
         leadStatusSelect.value = currentLead.status || 'New';
+        leadSourceSelect.value = currentLead.source || 'Other';
 
         // Display formatted created_at date
         const createdAtDateEl = leadCreatedAtEl.querySelector('span');
@@ -186,6 +214,15 @@ document.addEventListener('DOMContentLoaded', () => {
             viewOnMapBtn.style.display = 'inline-block';
         } else {
             viewOnMapBtn.style.display = 'none';
+        }
+
+        // Style hot lead button
+        if (currentLead.is_hot) {
+            hotLeadToggleButton.classList.add('btn-danger');
+            hotLeadToggleButton.classList.remove('btn-outline-secondary');
+        } else {
+            hotLeadToggleButton.classList.remove('btn-danger');
+            hotLeadToggleButton.classList.add('btn-outline-secondary');
         }
 
         // Render notes
@@ -316,6 +353,7 @@ document.addEventListener('DOMContentLoaded', () => {
             last_name: leadLastNameInput.value,
             phone: leadPhoneInput.value,
             status: leadStatusSelect.value,
+            source: leadSourceSelect.value,
             address: {
                 ...(currentLead.address || {}),
                 full_address: leadAddressInput.value
@@ -499,6 +537,7 @@ document.addEventListener('DOMContentLoaded', () => {
         snoozeLeadBtn.addEventListener('click', openSnoozeModal);
         confirmSnoozeBtn.addEventListener('click', confirmSnooze);
         addTaskForm.addEventListener('submit', handleAddLeadTask);
+        hotLeadToggleButton.addEventListener('click', toggleHotLead);
 
         document.getElementById('toggle-completed-tasks-btn').addEventListener('click', () => {
             showCompletedTasks = !showCompletedTasks;

--- a/static/js/leads.js
+++ b/static/js/leads.js
@@ -22,7 +22,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const kanbanBoard = document.getElementById('kanban-board');
     const searchInput = document.getElementById('lead-search-input');
     const hotLeadsFilterBtn = document.getElementById('hot-leads-filter-btn');
-    const showSnoozedCheckbox = document.getElementById('show-snoozed-checkbox');
+    const showSnoozedBtn = document.getElementById('show-snoozed-btn');
     const startDateFilter = document.getElementById('start-date-filter');
     const endDateFilter = document.getElementById('end-date-filter');
     const addLeadFab = document.getElementById('add-lead-fab');
@@ -179,7 +179,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const renderLeads = () => {
         const query = searchInput.value.toLowerCase();
         const showHotOnly = hotLeadsFilterBtn.classList.contains('active');
-        const showSnoozed = showSnoozedCheckbox.checked;
+        const showSnoozed = showSnoozedBtn.classList.contains('active');
         const startDate = startDateFilter.value;
         const endDate = endDateFilter.value;
         const now = new Date();
@@ -417,8 +417,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 hotLeadsFilterBtn.classList.toggle('active');
                 renderLeads();
             });
+            showSnoozedBtn.addEventListener('click', () => {
+                showSnoozedBtn.classList.toggle('active');
+                renderLeads();
+            });
             searchInput.addEventListener('input', renderLeads);
-            showSnoozedCheckbox.addEventListener('change', renderLeads);
             startDateFilter.addEventListener('change', renderLeads);
             endDateFilter.addEventListener('change', renderLeads);
             addLeadFab.addEventListener('click', () => addModal.show());

--- a/templates/lead_detail.html
+++ b/templates/lead_detail.html
@@ -38,6 +38,9 @@
         <div class="d-flex justify-content-between align-items-center mb-4">
             <h1 class="mb-0">Lead Details</h1>
             <div class="d-flex gap-2">
+                <button id="hot-lead-toggle-btn" class="btn btn-outline-secondary" title="Toggle Hot Lead">
+                    <i class="fas fa-fire"></i>
+                </button>
                 <button type="submit" form="lead-form" class="btn btn-primary" title="Save Changes">
                     <i class="fas fa-save"></i><span class="ms-2 d-none d-md-inline">Save</span>
                 </button>
@@ -100,6 +103,17 @@
                                 <div class="col-md-6 mb-3">
                                     <label for="lead-status" class="form-label">Status</label>
                                     <select id="lead-status" name="status" class="form-select"></select>
+                                </div>
+                                <div class="col-md-6 mb-3">
+                                    <label for="lead-source" class="form-label">Lead Source</label>
+                                    <select id="lead-source" name="source" class="form-select">
+                                        <option>Other</option>
+                                        <option>Facebook</option>
+                                        <option>Website</option>
+                                        <option>Home Show</option>
+                                        <option>Referral</option>
+                                        <option>Doors</option>
+                                    </select>
                                 </div>
                             </div>
                              <div class="mt-4">

--- a/templates/leads.html
+++ b/templates/leads.html
@@ -44,10 +44,9 @@
                 <input type="text" id="lead-search-input" class="form-control" placeholder="Search leads...">
                 <input type="date" id="start-date-filter" class="form-control">
                 <input type="date" id="end-date-filter" class="form-control">
-                <div class="form-check">
-                    <input class="form-check-input" type="checkbox" id="show-snoozed-checkbox">
-                    <label class="form-check-label" for="show-snoozed-checkbox">Show Snoozed</label>
-                </div>
+                <button id="show-snoozed-btn" class="btn btn-outline-secondary" title="Show/Hide Snoozed Leads">
+                    <i class="fas fa-bell-slash"></i>
+                </button>
             </div>
         </div>
         <div id="kanban-board" class="mt-3">


### PR DESCRIPTION
This commit addresses several UI/UX improvements:

1.  **Limit Lead Card Height:** The text in lead cards on the Kanban board is now truncated to 4 lines to prevent cards from becoming excessively tall.
2.  **Flame Toggle on Detail Page:** A "hot lead" toggle button, identical to the one on the Kanban page, has been added to the lead detail page for quick status updates.
3.  **Lead Source on Detail Page:** The lead source is now a visible and editable field on the lead detail page, ensuring all lead information is accessible.
4.  **Visible Count on Collapsed Columns:** The lead count badge now remains visible at the top of a column when it is collapsed in the Kanban view.
5.  **Icon for "Show Snoozed":** The "Show Snoozed" checkbox on the Kanban page has been replaced with a more intuitive toggle button with a snooze icon.