### PR TITLE
Fix Kanban column styling and add Get Directions button

### DIFF
--- a/app_output.log
+++ b/app_output.log
@@ -1,0 +1,4 @@
+Traceback (most recent call last):
+  File "/app/app.py", line 4, in <module>
+    from flask import Flask, jsonify, render_template, request, abort
+ModuleNotFoundError: No module named 'flask'

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -132,9 +132,9 @@ body {
     margin: 0;
     padding: 0.5rem;
     display: flex;
-    justify-content: space-between;
+    justify-content: flex-end;
+    gap: 1rem;
     align-items: center;
-    height: 100%;
     width: 100%;
     border-bottom: none;
     background-color: transparent;

--- a/static/js/lead_detail.js
+++ b/static/js/lead_detail.js
@@ -216,6 +216,15 @@ document.addEventListener('DOMContentLoaded', () => {
             viewOnMapBtn.style.display = 'none';
         }
 
+        // Set up Get Directions link
+        const getDirectionsBtn = document.getElementById('get-directions-btn');
+        if (getDirectionsBtn && currentLead.address && currentLead.address.lat && currentLead.address.lng) {
+            getDirectionsBtn.href = `https://www.google.com/maps/dir/?api=1&destination=${currentLead.address.lat},${currentLead.address.lng}`;
+            getDirectionsBtn.style.display = 'inline-block';
+        } else if (getDirectionsBtn) {
+            getDirectionsBtn.style.display = 'none';
+        }
+
         // Style hot lead button
         if (currentLead.is_hot) {
             hotLeadToggleButton.classList.add('btn-danger');

--- a/static/js/map.js
+++ b/static/js/map.js
@@ -208,11 +208,19 @@ document.addEventListener('DOMContentLoaded', () => {
     const generatePopupContent = (lead) => {
         const fullName = `${lead.first_name || ''} ${lead.last_name || ''}`.trim() || 'Unnamed Lead';
         const addressStr = lead.address?.full_address || 'No address provided';
+        const directionsHref = (lead.address && lead.address.lat && lead.address.lng)
+            ? `https://www.google.com/maps/dir/?api=1&destination=${lead.address.lat},${lead.address.lng}`
+            : '#';
+        const directionsLink = (lead.address && lead.address.lat && lead.address.lng)
+            ? `<a href="${directionsHref}" target="_blank" class="btn btn-sm btn-outline-primary ms-2" title="Get Directions"><i class="fas fa-directions"></i></a>`
+            : '';
+
         return `<b>${fullName}</b><br>
                 Status: ${lead.status || 'N/A'}<br>
                 ${addressStr}<br>
                 ${lead.phone || ''}
-                <br><a href="/leads/${lead.id}" class="fw-bold">View Details</a>`;
+                <br><a href="/leads/${lead.id}" class="fw-bold">View Details</a>
+                ${directionsLink}`;
     };
 
     const addLeadMarker = (lead) => {

--- a/templates/lead_detail.html
+++ b/templates/lead_detail.html
@@ -96,7 +96,12 @@
                             </div>
                             <div class="mb-3">
                                 <label for="lead-address" class="form-label">Address</label>
-                                <input type="text" class="form-control" id="lead-address" name="address" autocomplete="off">
+                                <div class="input-group">
+                                    <input type="text" class="form-control" id="lead-address" name="address" autocomplete="off">
+                                    <a id="get-directions-btn" href="#" class="btn btn-outline-secondary" title="Get Directions" target="_blank">
+                                        <i class="fas fa-directions"></i>
+                                    </a>
+                                </div>
                                 <div id="address-suggestions-detail" class="address-suggestions list-group"></div>
                             </div>
                             <div class="row">


### PR DESCRIPTION
- Aligns the title and lead count at the top of collapsed Kanban columns.
- Adds a 'Get Directions' button to the map view popup, which opens Google Maps with directions to the lead's address.
- Adds a 'Get Directions' button to the lead detail page next to the address field.