### PR TITLE
Fix: Adjust map controls on mobile to prevent overlap

### DIFF
--- a/flask_app.log
+++ b/flask_app.log
@@ -1,0 +1,10 @@
+ * Serving Flask app 'app'
+ * Debug mode: on
+[31m[1mWARNING: This is a development server. Do not use it in a production deployment. Use a production WSGI server instead.[0m
+ * Running on all addresses (0.0.0.0)
+ * Running on http://127.0.0.1:5001
+ * Running on http://192.168.0.2:5001
+[33mPress CTRL+C to quit[0m
+ * Restarting with stat
+ * Debugger is active!
+ * Debugger PIN: 610-203-682

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -168,6 +168,20 @@ body {
     white-space: normal; /* Override any white-space settings */
 }
 
+@media (max-width: 991.98px) {
+    #custom-controls-container,
+    #filter-control-container {
+        /* Move controls down to avoid overlapping the expanded navbar */
+        top: 125px;
+    }
+
+    #filter-panel {
+        /* Adjust filter panel to not go off-screen */
+        right: 0;
+        left: auto;
+    }
+}
+
 /* Style for the active state of icon-based toggle buttons */
 #show-completed-tasks-toggle.active,
 #hot-leads-filter-btn.active,


### PR DESCRIPTION
The map controls (center, search, filter) were overlapping with the expanded navigation menu on mobile devices.

This was because they were absolutely positioned with a fixed `top` value that didn't account for the height of the expanded navbar.

This change introduces a media query for screens narrower than 992px (the Bootstrap 'lg' breakpoint) to move the controls further down the page, ensuring they appear below the navigation menu.