### PR TITLE
fix(tasks): Increase clickable area for task action icons

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -327,14 +327,6 @@ body {
     font-weight: bold;
 }
 
-.task-actions button {
-    opacity: 0.5;
-}
-
-.task-item:hover .task-actions button {
-    opacity: 1;
-}
-
 .task-list-item {
     display: flex;
     justify-content: space-between;
@@ -342,12 +334,32 @@ body {
 }
 
 .task-list-item .task-actions {
-    opacity: 0;
+    opacity: 1;
     transition: opacity 0.2s ease-in-out;
+    display: flex;
+    gap: 0.5rem;
 }
 
-.task-list-item:hover .task-actions {
-    opacity: 1;
+.task-action-btn {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    background-color: #f0f0f0;
+    border: 1px solid #ccc;
+    color: #333;
+}
+
+.task-action-btn:hover {
+    background-color: #e0e0e0;
+    border-color: #999;
+}
+
+.task-action-btn .fa-trash-alt {
+    color: #dc3545;
 }
 
 .card-footer {

--- a/static/js/lead_detail.js
+++ b/static/js/lead_detail.js
@@ -482,8 +482,8 @@ document.addEventListener('DOMContentLoaded', () => {
                     <span>${task.title}</span>
                 </div>
                 <div class="task-actions">
-                    <button class="edit-task-btn btn btn-sm btn-link text-secondary" title="Edit Task"><i class="fas fa-pencil-alt"></i></button>
-                    <button class="delete-task-btn btn btn-sm btn-link text-danger" title="Delete Task"><i class="fas fa-trash-alt"></i></button>
+                    <button class="edit-task-btn btn btn-sm task-action-btn" title="Edit Task"><i class="fas fa-pencil-alt"></i></button>
+                    <button class="delete-task-btn btn btn-sm task-action-btn" title="Delete Task"><i class="fas fa-trash-alt"></i></button>
                 </div>
             `;
             tasksListEl.appendChild(li);


### PR DESCRIPTION
The pencil and trash can icons for tasks on the lead details page were previously hard to click or tap due to their small size.

This change addresses the issue by:
- Replacing the `btn-link` style with a custom-styled button to provide a larger, visible target.
- Increasing the button size and ensuring the icon is centered within it.
- Making the action buttons always visible, improving usability on touch devices where hover interactions are not possible.